### PR TITLE
dynwrap 0.3.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dynwrap
 Type: Package
 Title: Common trajectory model for representing trajectories from all sources
-Version: 0.3.0.9000
+Version: 0.3.1
 Authors@R: c(
     person(
       "Robrecht", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dynwrap
 Type: Package
 Title: Common trajectory model for representing trajectories from all sources
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R: c(
     person(
       "Robrecht", 

--- a/R/method_process_definition.R
+++ b/R/method_process_definition.R
@@ -7,6 +7,7 @@
   # TODO: Expand testing of definition, in case 3rd party containers are naughty
 
   # create inputs tibble
+  utils::data("priors", package = "dynwrap", envir = environment()) # TODO: move to sysdata, avoiding loading of priors
   definition$inputs <-
     data_frame(
       input_id = c(definition$input$required, definition$input$optional, definition$parameters$id),

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,7 +39,7 @@ The advantage of using a common model is that it allows:
 
 
 ## Latest changes
-Check out `news(package = "dynfeature")` or [NEWS.md](inst/NEWS.md) for a full list of changes.
+Check out `news(package = "dynwrap")` or [NEWS.md](inst/NEWS.md) for a full list of changes.
 
 <!-- This section gets automatically generated from inst/NEWS.md, and also generates inst/NEWS -->
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,13 @@ The advantage of using a common model is that it allows:
 
 ## Latest changes
 
-Check out `news(package = "dynfeature")` or [NEWS.md](inst/NEWS.md) for
-a full list of
+Check out `news(package = "dynwrap")` or [NEWS.md](inst/NEWS.md) for a
+full list of
 changes.
 
 <!-- This section gets automatically generated from inst/NEWS.md, and also generates inst/NEWS -->
+
+### Latest changes in dynwrap 0.4.0 (unreleased)
 
 ### Latest changes in dynwrap 0.3.0 (19-11-2018)
 
@@ -67,27 +69,3 @@ changes.
 
   - CLEAN UP: Remove `parse_parameter_definition()` and thereby
     dependency on ParamHelpers.
-
-### Latest changes in dynwrap 0.2.0 (29-10-2018)
-
-  - BUG FIX: Fixed incorrect calculation of milestone percentage during
-    trajectory simplification. Occurs only in a rare edge case, namely
-    when the order of the milestones in the milestone network is very
-    different from the order of the milestone ids (0475e94).
-
-  - BUG FIX: Fixed suggested dependencies not being installed in the
-    dynwrap containers (\#100).
-
-  - FEATURE REMOVAL: Removed feather data format because it’s not being
-    used and creates dependency issues every now and again.
-
-  - BUG FIX: `devtools:::shim_system.file()` has been moved to
-    `pkgload:::shim_system.file()`.
-
-  - TESTING: Solved issue with the unit tests by not using any helpers.
-
-  - MINOR CHANGE: Have docker images build from <dynwrap@devel>.
-
-  - BUG FIX: Remove `option(echo = FALSE)` from .Rprofile in recipes
-    because some packages directly rely on standard output from R, so
-    printing the command wreaks havoc.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ changes.
 
 <!-- This section gets automatically generated from inst/NEWS.md, and also generates inst/NEWS -->
 
-### Latest changes in dynwrap 0.4.0 (unreleased)
+### Latest changes in dynwrap 0.3.1 (19-11-2018)
+
+  - HOTFIX: Use `utils::data()` to get access to `priors`.
 
 ### Latest changes in dynwrap 0.3.0 (19-11-2018)
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,4 +1,6 @@
-dynwrap 0.4.0 (unreleased)
+dynwrap 0.3.1 (19-11-2018)
+
+* HOTFIX: Use `utils::data()` to get access to `priors`.
 
 dynwrap 0.3.0 (19-11-2018)
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,5 @@
+dynwrap 0.4.0 (unreleased)
+
 dynwrap 0.3.0 (19-11-2018)
 
 * MINOR CHANGE: Added metadata on the different wrapper types implemented in dynwrap.

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,4 +1,6 @@
-# dynwrap 0.4.0 (unreleased)
+# dynwrap 0.3.1 (19-11-2018)
+
+* HOTFIX: Use `utils::data()` to get access to `priors`.
 
 # dynwrap 0.3.0 (19-11-2018)
 

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,3 +1,5 @@
+# dynwrap 0.4.0 (unreleased)
+
 # dynwrap 0.3.0 (19-11-2018)
 
 * MINOR CHANGE: Added metadata on the different wrapper types implemented in dynwrap.


### PR DESCRIPTION
* HOTFIX: Use `utils::data()` to get access to `priors`.