### PR TITLE
set seed based on current random state

### DIFF
--- a/R/method_infer_trajectory.R
+++ b/R/method_infer_trajectory.R
@@ -32,7 +32,7 @@ infer_trajectories <- function(
   method,
   parameters = NULL,
   give_priors = NULL,
-  seed = 1,
+  seed = sample(1:.Machine$integer.max, 1),
   verbose = FALSE,
   return_verbose = FALSE,
   debug = FALSE,

--- a/R/method_infer_trajectory.R
+++ b/R/method_infer_trajectory.R
@@ -173,6 +173,9 @@ infer_trajectory <- dynutils::inherit_default_params(
       error <- design$summary[[1]]$error[[1]]
       cat("Error traceback:\n")
       traceback(error)
+      if (!is.list(error)) { # if no error yet, add a fake one
+        error <- list(message = "")
+      }
       stop("Error during trajectory inference \n", error$message, call. = FALSE)
     } else {
       first(design$model)


### PR DESCRIPTION
This ensures that users who de `set.seed(...)` will always get the same result when doing `infer_trajectory`, as long as the seed is passed on to the method :innocent: 