### PR TITLE
dynwrap 1.1.3

### DIFF
--- a/R/method_create_ti_method_container.R
+++ b/R/method_create_ti_method_container.R
@@ -82,10 +82,12 @@ create_ti_method_container <- function(
   # save data to file
   dynutils::write_h5(task, file.path(paths$dir_dynwrap, "input.h5"))
 
-  # return path information
+  # add extra information
+  paths$prior_names <- names(priors)
   paths$debug <- debug
   paths$verbose <- verbose
 
+  # return path information
   paths
 }
 
@@ -99,6 +101,12 @@ create_ti_method_container <- function(
 
   args <- c("--dataset", "/ti/input.h5", "--output", "/ti/output.h5")
   if (preproc_meta$debug) args <- c(args, "--debug")
+
+  if (!is.null(preproc_meta$prior_names)) {
+    # only the priors that were specified earlier
+    # have been saved to a file, so specifying 'all' is ok
+    args <- c(args, "--use_priors", "all")
+  }
 
   # run container
   output <- babelwhale::run(

--- a/README.md
+++ b/README.md
@@ -51,15 +51,19 @@ changes.
 
 <!-- This section gets automatically generated from inst/NEWS.md, and also generates inst/NEWS -->
 
+### Recent changes in dynwrap 1.1.3 (05-06-2019)
+
+  - MINOR CHANGE `add_dimred()`: Add a separate argument for specifying
+    the projected dimred rather than expecting the projected dimred to
+    be passed as additional columns in `dimred`.
+
+  - BUG FIX: Fix for dynverse/dyno\#52, do specify whether or not to use
+    optional priors when passed
+
 ### Recent changes in dynwrap 1.1.2 (08-05-2019)
 
-  - FEATURE: Add leaves\_n as prior information
-
-### Recent changes in dynwrap 1.1.1 (08-05-2019)
-
-  - BUG FIX: Fixed bug for directed geodesic distances with disconnected
-    graphs,
-dynverse/dynplot\#37
+  - FEATURE: Add leaves\_n as prior
+information
 
 ## Dynverse dependencies
 

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,10 @@
+dynwrap 1.1.3 (05-06-2019)
+
+* MINOR CHANGE `add_dimred()`: Add a separate argument for specifying the projected dimred rather than
+  expecting the projected dimred to be passed as additional columns in `dimred`.
+
+* BUG FIX: Fix for dynverse/dyno#52, do specify whether or not to use optional priors when passed
+
 dynwrap 1.1.2 (08-05-2019)
 
 * FEATURE: Add leaves_n as prior information

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,3 +1,10 @@
+# dynwrap 1.1.3 (05-06-2019)
+
+* MINOR CHANGE `add_dimred()`: Add a separate argument for specifying the projected dimred rather than
+  expecting the projected dimred to be passed as additional columns in `dimred`.
+
+* BUG FIX: Fix for dynverse/dyno#52, do specify whether or not to use optional priors when passed
+
 # dynwrap 1.1.2 (08-05-2019)
 
 * FEATURE: Add leaves_n as prior information

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -3,7 +3,7 @@
 * MINOR CHANGE `add_dimred()`: Add a separate argument for specifying the projected dimred rather than
   expecting the projected dimred to be passed as additional columns in `dimred`.
 
-* BUG FIX: Fix for dynverse/dyno#52, do specify whether or not to use optional priors when passed
+* BUG FIX: Fix for dynverse/dyno#52, do specify whether or not to use optional priors when passed.
 
 # dynwrap 1.1.2 (08-05-2019)
 

--- a/man/add_dimred.Rd
+++ b/man/add_dimred.Rd
@@ -6,9 +6,10 @@
 \alias{get_dimred}
 \title{Add or create a dimensionality reduction}
 \usage{
-add_dimred(dataset, dimred, dimred_milestones = NULL,
-  dimred_segment_progressions = NULL, dimred_segment_points = NULL,
-  connect_segments = FALSE, project_trajectory = TRUE,
+add_dimred(dataset, dimred, dimred_projected = NULL,
+  dimred_milestones = NULL, dimred_segment_progressions = NULL,
+  dimred_segment_points = NULL, connect_segments = FALSE,
+  project_trajectory = TRUE,
   pair_with_velocity = !is.null(dataset$expression_projected),
   expression_source = "expression", ...)
 
@@ -20,6 +21,8 @@ get_dimred(dataset, dimred = NULL, expression_source = "expression")
 \item{dataset}{A dataset created by \code{\link[=wrap_data]{wrap_data()}} or \code{\link[=wrap_expression]{wrap_expression()}}}
 
 \item{dimred}{The dimensionality reduction matrix (with cell_ids as rownames) or function which will run the dimensionality reduction}
+
+\item{dimred_projected}{An optional dimensionality reduction of the projected cells (RNA velocity).}
 
 \item{dimred_milestones}{An optional dimensionality reduction of the milestones.}
 


### PR DESCRIPTION
* MINOR CHANGE `add_dimred()`: Add a separate argument for specifying the projected dimred rather than expecting the projected dimred to be passed as additional columns in `dimred`.

* BUG FIX: Fix for dynverse/dyno#52, do specify whether or not to use optional priors when passed.