### PR TITLE
Fix for upcoming purrr release

### DIFF
--- a/R/method_process_definition.R
+++ b/R/method_process_definition.R
@@ -320,12 +320,12 @@ is_ti_method <- function(method) {
 #' @export
 convert_definition <- function(definition_raw) {
   definition(
-    method = purrr::invoke(def_method, definition_raw$method %||% list()),
-    wrapper = purrr::invoke(def_wrapper, definition_raw$wrapper %||% list()),
-    container = purrr::invoke(def_container, definition_raw$container %||% list()),
-    package = purrr::invoke(def_package, definition_raw$package %||% list()),
-    manuscript = purrr::invoke(def_manuscript, definition_raw$manuscript %||% list()),
-    parameters = dynparam::as_parameter_set(definition_raw$parameters %||% list())
+    method = purrr::exec(def_method, !!!definition_raw$method),
+    wrapper = purrr::exec(def_wrapper, !!!definition_raw$wrapper),
+    container = purrr::exec(def_container, !!!definition_raw$container),
+    package = purrr::exec(def_package, !!!definition_raw$package),
+    manuscript = purrr::exec(def_manuscript, !!!definition_raw$manuscript),
+    parameters = dynparam::as_parameter_set(definition_raw$parameters)
   )
 }
 

--- a/R/wrap_add_dimred.R
+++ b/R/wrap_add_dimred.R
@@ -58,8 +58,8 @@ add_dimred <- function(
   if (is.matrix(dimred) || is.data.frame(dimred)) {
     dimred <- process_dimred(dataset, dimred)
     assert_that(
-      rownames(dimred) %all_in% dataset$cell_id,
-      dataset$cell_id %all_in% rownames(dimred)
+      rownames(dimred) %all_in% dataset$cell_ids,
+      dataset$cell_ids %all_in% rownames(dimred)
     )
 
   } else {


### PR DESCRIPTION
`invoke()` is now fully deprecated, so I've switch to `exec()`. I didn't see any tests for this function so I'm not 100% correct it still works, but this change did remove the warning from the SCORPIUS package without other changes.

(I also included a fix for a partial match warning that triggered in a lot of tests. I'd suggest you also run down the dplyr warning.)